### PR TITLE
[MCKIN-8112] Changes required to work with Ginkgo Django 1.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,20 @@ otherwise noted.
 
 Please see ``LICENSE.txt`` for details.
 
+Testing
+-------
+
+This package uses ``tox`` to run the tests against multiple combinations of python and django versions.
+
+To run the the full test suite:
+
+..code_block::
+
+    $ mkvirtualenv venv
+    $ make requirements
+    $ make test-all
+
+
 How To Contribute
 -----------------
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,18 +3,21 @@ Tests for User Manager Application views
 """
 from __future__ import absolute_import, unicode_literals
 
-import json
-
 import ddt
 from mock import PropertyMock, patch
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.test import APIClient
 
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
-from django.urls import reverse
+from django.test import TestCase
 
 from user_manager.api.v1.views import ManagerViewMixin
 from user_manager.models import UserManagerRole
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 
 
 @ddt.ddt
@@ -41,8 +44,8 @@ class UserManagerRoleViewsTest(TestCase):
         self.user = User.objects.create(username='staff', email='staff@example.org', is_staff=True)
         self.user.set_password('test')
         self.user.save()
-        self.client = Client()
-        self.client.login(username=self.user.username, password='test')
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
         self.users = list(self._create_users())
         self.managers = list(self._create_managers())
         for user in self.users[:5]:
@@ -63,8 +66,8 @@ class UserManagerRoleViewsTest(TestCase):
 
     def test_no_duplicate_managers(self):
         response = self.client.get(reverse('v1:managers-list'))
-        data = json.loads(response.content)
-        results = data['results']
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
         self.assertEqual(len(results), 2)
 
     @ddt.data('username', 'email')
@@ -74,8 +77,8 @@ class UserManagerRoleViewsTest(TestCase):
             kwargs={'username': getattr(self.managers[0], attr)},
         )
         response = self.client.get(url)
-        data = json.loads(response.content)
-        results = data['results']
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
         self.assertEqual(len(results), 5)
 
     def test_manager_reports_list_post_duplicate(self):
@@ -94,14 +97,15 @@ class UserManagerRoleViewsTest(TestCase):
         )
         response = self.client.post(url, {'email': 'non@existent.com'})
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.content, '{"detail":"No user with that email"}')
+        self.assertEqual(response.data, {"detail": "No user with that email"})
 
     def test_manager_reports_list_delete_all(self):
         url = reverse(
             'v1:manager-reports-list',
             kwargs={'username': self.managers[0].email},
         )
-        self.client.delete(url)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204)
         query = UserManagerRole.objects.filter(manager_user=self.managers[0])
         self.assertEqual(query.count(), 0)
 
@@ -110,9 +114,10 @@ class UserManagerRoleViewsTest(TestCase):
             'v1:manager-reports-list',
             kwargs={'username': self.managers[0].email},
         )
-        self.client.delete(
+        response = self.client.delete(
             '{url}?user={email}'.format(url=url, email=self.users[0].email)
         )
+        self.assertEqual(response.status_code, 204)
         query = UserManagerRole.objects.filter(manager_user=self.managers[0])
         self.assertEqual(query.count(), 4)
         self.assertNotIn(self.users[0].email, query.values_list('user__email', flat=True))
@@ -135,8 +140,8 @@ class UserManagerRoleViewsTest(TestCase):
             kwargs={'username': getattr(self.users[0], attr)},
         )
         response = self.client.get(url)
-        data = json.loads(response.content)
-        results = data['results']
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
         self.assertEqual(len(results), 2)
 
     def test_user_managers_list_post_duplicate(self):
@@ -153,7 +158,8 @@ class UserManagerRoleViewsTest(TestCase):
             'v1:user-managers-list',
             kwargs={'username': self.users[0].email},
         )
-        self.client.post(url, {'email': 'unregistered@user.com'})
+        response = self.client.post(url, {'email': 'unregistered@user.com'})
+        self.assertEqual(response.status_code, 201)
         query = UserManagerRole.objects.filter(user=self.users[0])
         self.assertEqual(query.count(), 3)
         self.assertIn(
@@ -166,7 +172,8 @@ class UserManagerRoleViewsTest(TestCase):
             'v1:user-managers-list',
             kwargs={'username': self.users[0].email},
         )
-        self.client.delete(url)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 204)
         query = UserManagerRole.objects.filter(user=self.users[0])
         self.assertEqual(query.count(), 0)
 
@@ -177,9 +184,10 @@ class UserManagerRoleViewsTest(TestCase):
             'v1:user-managers-list',
             kwargs={'username': self.users[0].email},
         )
-        self.client.delete(
+        response = self.client.delete(
             '{url}?manager={email}'.format(url=url, email=self.managers[0].email)
         )
+        self.assertEqual(response.status_code, 204)
         query = UserManagerRole.objects.filter(user=self.users[0])
         self.assertEqual(query.count(), 1)
         self.assertNotIn(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35}-django111,py35-django20,quality,docs
+envlist = {py27}-django18,{py27,py35}-django111,py35-django20,quality,docs
 
 [doc8]
 max-line-length = 120
@@ -24,6 +24,7 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
+    django18: Django==1.8.18
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django18: Django==1.8.18
+    django18: Django>=1.8,<1.9
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt

--- a/user_manager/api/urls.py
+++ b/user_manager/api/urls.py
@@ -8,5 +8,5 @@ from django.conf.urls import include, url
 from .v1 import urls
 
 urlpatterns = [
-    url(r'^v1/', include((urls, 'user_manager'), namespace='v1')),
+    url(r'^v1/', include(urls, namespace='v1')),
 ]

--- a/user_manager/api/v1/urls.py
+++ b/user_manager/api/v1/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = "user_manager"
+
 urlpatterns = [
     url(
         r'^managers/$',


### PR DESCRIPTION
**Description:** 

Fixes incompatibilities encountered when running this library with Django 1.8, e.g. https://code.djangoproject.com/ticket/28691

**JIRA:** MCKIN-8112

**Dependencies:** None

**Installation instructions:**

Installation instructions for ginkgo edx-platform, which does not support django app plugins:

1. Install this package in the edxapp virtualenv.
1. Add `user_manager` to the `lms.env.common.INSTALLED_APPS` list.
1. Add the urls to the `lms.urls`:
   ```python
   urlpatterns += (
       url(r'^api/user_manager/', include('user_manager.api.urls', namespace='user-manager-api')),
   )
   ```
1. Run migrations to get the new tables.

**Testing instructions:**

Manual tests:
1. Open http://localhost:8000/api/user_manager/v1/managers/
1. Expect the page to load without error.

Automated tests:
1. See updated [README.rst](https://github.com/mckinseyacademy/openedx-user-manager-api/pull/2/files#diff-88b99bb28683bd5b7e3a204826ead112) for testing instructions.

**Reviewers:**
- [ ] @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag 
- [ ] Check new version is pushed to PyPI after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

1. I encountered this error when backporting this application to Ginkgo (edx-solutions), so am unsure whether it happens in edx-platform `master`.
1. I also tried removing the `namespace` parameter from the url include in `lms.urls`, but it did not resolve the issue.