### PR TITLE
Bulk API for creating reports under managers

### DIFF
--- a/user_manager/api/v1/serializers.py
+++ b/user_manager/api/v1/serializers.py
@@ -38,7 +38,7 @@ class ManagerListSerializer(serializers.Serializer):  # pylint: disable=abstract
 class ManagerReportsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """ Serializer for User manager reports """
 
-    email = fields.EmailField(source='user.email')
+    email = fields.EmailField(source='user.email', required=False)
     username = fields.CharField(source='user.username', required=False)
 
     def create(self, validated_data):

--- a/user_manager/utils.py
+++ b/user_manager/utils.py
@@ -3,6 +3,8 @@ Utilities for User Manager Application.
 """
 from __future__ import absolute_import, unicode_literals
 
+from django.contrib.auth.models import User
+
 from .models import UserManagerRole
 
 
@@ -23,3 +25,14 @@ def create_user_manager_role(user, manager_user=None, manager_email=None):
     else:
         raise ValueError('Both manager_user and manager_email cannot be None')
     return obj
+
+
+def get_user_by_username_or_email(identifier):
+    """
+    Get user by identifier, which could be an email or username.
+    """
+
+    if '@' in identifier:
+        return User.objects.get(email=identifier)
+    else:
+        return User.objects.get(username=identifier)


### PR DESCRIPTION
## Support bulk creation for managers' CRUD

**JIRA:** [OC-4965](https://tasks.opencraft.com/browse/OC-4965)

### Description:
This change introduces a bulk creation of reports under a specific manager using the endpoint: [/v1/managers/{manager_id}/reports/](). A normal request would be a `POST` one contains a list of reports' `user_id`s we want to add under that manager.

#### Accepted parameters
A JSON list of objects each contains one of the following:

* `username`: The username or email address for the user for whom you want to add a manger to.
* `email`: The email address for a user for whom you want to add a manger to.

#### Expected Response
The response will contain the following data:
* `results`: An array of the successfully created reports.
* `errors`: An array contains the errors faced during the creation process. (Each object may have one error)

> NOTE: `errors` array will not be present in case there are no errors while handling the request.

#### Expected Response Statuses:
* `201 CREATED` if the API was able to create reports for all of the provided users in the list.
* `202 ACCEPTED` if the API faced at least one error during the process.

#### Example:

**Request**

```JS
POST /api/user_manager/v1/managers/{user_id}/reports/ [
    {
        "username": "user"
    },
    {
        "email": "email@example.com"
    },
    {
        "email": "anotheremail@example.com"
    }
]
```

**Response**

```JS
{
    "errors": [
        {
            "detail": "No user with that identifier: anotheremail@example.com"
        }
    ],
    "results": [
        {
            "email": "user@example.com",
            "username": "user"
        },
        {
            "email": "email@example.com",
            "username": "email"
        }
    ]
}
```